### PR TITLE
Address Issues with MessageUpdate() and listMessageAdd()

### DIFF
--- a/plugins/restapi/includes/lists.php
+++ b/plugins/restapi/includes/lists.php
@@ -222,7 +222,7 @@ class Lists {
     static function listMessageAdd( $list_id=0, $message_id=0 ){
         if ( $list_id==0 ) $list_id = $_REQUEST['list_id'];
         if ( $message_id==0 ) $message_id = $_REQUEST['message_id'];
-        $sql = "INSERT INTO " . $GLOBALS['table_prefix'] . "listmessage (messageid, listid, entered) VALUES (:message_id, :list_id, now()) ON DUPLICATE KEY UPDATE list_id=:list_id;";
+        $sql = "INSERT INTO " . $GLOBALS['table_prefix'] . "listmessage (messageid, listid, entered) VALUES (:message_id, :list_id, now()) ON DUPLICATE KEY UPDATE listid=:list_id;";
         try {
             $db = PDO::getConnection();
             $stmt = $db->prepare($sql);

--- a/plugins/restapi/includes/lists.php
+++ b/plugins/restapi/includes/lists.php
@@ -222,7 +222,7 @@ class Lists {
     static function listMessageAdd( $list_id=0, $message_id=0 ){
         if ( $list_id==0 ) $list_id = $_REQUEST['list_id'];
         if ( $message_id==0 ) $message_id = $_REQUEST['message_id'];
-        $sql = "INSERT INTO " . $GLOBALS['table_prefix'] . "listmessage (messageid, listid, entered) VALUES (:message_id, :list_id, now());";
+        $sql = "INSERT INTO " . $GLOBALS['table_prefix'] . "listmessage (messageid, listid, entered) VALUES (:message_id, :list_id, now()) ON DUPLICATE KEY UPDATE list_id=:list_id;";
         try {
             $db = PDO::getConnection();
             $stmt = $db->prepare($sql);

--- a/plugins/restapi/includes/messages.php
+++ b/plugins/restapi/includes/messages.php
@@ -106,7 +106,7 @@ class Messages{
             $stmt->bindParam("status", $_REQUEST['status'] );
             $stmt->bindParam("sendformat", $_REQUEST['sendformat'] );
             $stmt->bindParam("template", $_REQUEST['template'] );
-            $stmt->bindParam("sendstart", $_REQUEST['sendstart'] );
+            $stmt->bindParam("embargo", $_REQUEST['embargo'] );
             $stmt->bindParam("rsstemplate", $_REQUEST['rsstemplate'] );
             $stmt->bindParam("owner", $_REQUEST['owner'] );
             $stmt->bindParam("htmlformatted", $_REQUEST['htmlformatted'] );

--- a/plugins/restapi/includes/messages.php
+++ b/plugins/restapi/includes/messages.php
@@ -92,7 +92,7 @@ class Messages{
     static function messageUpdate( $id = 0 ){
 
         if ( $id == 0 ) $id = $_REQUEST['id'];
-        $sql = "UPDATE " . $GLOBALS['table_prefix'] . "message SET subject=:subject, fromfield=:fromfield, replyto=:replyto, message=:message, textmessage=:textmessage, footer=:footer, status=:status, sendformat=:sendformat, template=:template, sendstart=:sendstart, rsstemplate=:rsstemplate, owner=:owner, htmlformatted=:htmlformatted WHERE id=:id;";
+        $sql = "UPDATE " . $GLOBALS['table_prefix'] . "message SET subject=:subject, fromfield=:fromfield, replyto=:replyto, message=:message, textmessage=:textmessage, footer=:footer, status=:status, sendformat=:sendformat, template=:template, embargo=:embargo, rsstemplate=:rsstemplate, owner=:owner, htmlformatted=:htmlformatted WHERE id=:id;";
         try {
             $db = PDO::getConnection();
             $stmt = $db->prepare($sql);


### PR DESCRIPTION
- __messageUpdate()__ was accepting the field `sendstart` instead of `embargo` as indicated in the description. Updating the messsage embargo is more useful than updating the sendstart, which AFAIK is automatically set when the message starts to be sent out.

- __listMessageAdd()__ was raising an error on duplicate key. When adding a message to a list you should not need to check if it is already added to that list, therefore an update on duplicate key would be more appropriate.