### PR TITLE
Issue #59 - Fix incorrect SQL statement parameter

### DIFF
--- a/plugins/restapi/includes/campaigns.php
+++ b/plugins/restapi/includes/campaigns.php
@@ -162,7 +162,7 @@ class Campaigns
         if ($id == 0) {
             $id = $_REQUEST['id'];
         }
-        $sql = 'UPDATE '.$GLOBALS['tables']['message'].' SET subject=:subject, fromfield=:fromfield, replyto=:replyto, message=:message, textmessage=:textmessage, footer=:footer, status=:status, sendformat=:sendformat, template=:template, sendstart=:sendstart, rsstemplate=:rsstemplate, owner=:owner, htmlformatted=:htmlformatted WHERE id=:id;';
+        $sql = 'UPDATE '.$GLOBALS['tables']['message'].' SET subject=:subject, fromfield=:fromfield, replyto=:replyto, message=:message, textmessage=:textmessage, footer=:footer, status=:status, sendformat=:sendformat, template=:template, embargo=:embargo, rsstemplate=:rsstemplate, owner=:owner, htmlformatted=:htmlformatted WHERE id=:id;';
         try {
             $db = PDO::getConnection();
             $stmt = $db->prepare($sql);


### PR DESCRIPTION
The SQL parameter should be embargo instead of sendstart.

This should fix https://github.com/phpList/phplist-plugin-restapi/issues/59