### PR TITLE
Change default character set from UTF8 to UTF8MB4

### DIFF
--- a/plugins/restapi/includes/pdo.php
+++ b/plugins/restapi/includes/pdo.php
@@ -15,7 +15,7 @@ class PDO extends \PDO
         $dbuser = $GLOBALS['database_user'];
         $dbpass = $GLOBALS['database_password'];
         $dbname = $GLOBALS['database_name'];
-        $dbh = new \PDO("mysql:host=$dbhost;dbname=$dbname;charset=UTF8;", $dbuser, $dbpass, array(PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES 'utf8';"));
+        $dbh = new \PDO("mysql:host=$dbhost;dbname=$dbname;charset=UTF8MB4;", $dbuser, $dbpass, array(PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES 'utf8mb4';"));
         $dbh->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
 
         return $dbh;


### PR DESCRIPTION
In order to allow emojis and other extended character sets, database tables need to be updated to use UTF8MB4, which seems to work well within the phpList app proper.

The API using UTF8 encoding prevents extended characters from being stored in the database tables.

As I believe UTF8MB4 is a superset of UTF8, this change does not impact installations using UTF8, but does allow those with UTF8MB4 access to the full set of allowed characters.