### PR TITLE
Fixes for problems with running restapi tests

### DIFF
--- a/plugins/restapi/call.php
+++ b/plugins/restapi/call.php
@@ -52,20 +52,20 @@ if ($cmd != 'login') {
 }
 $ipAddress = getConfig('restapi_ipaddress');
 if (!empty($ipAddress) && ($GLOBALS['remoteAddr'] != $ipAddress)) {
-    $response->outputErrorMessage('Incorrect ip address for request. Check your settings.');
+    Response::outputErrorMessage('Incorrect ip address for request. Check your settings.');
     die(0);
-} 
+}
 $requireSecret = getConfig('restapi_usesecret');
 if ($requireSecret) {
   $secret = getConfig('remote_processing_secret');
   if (empty($_REQUEST['secret']) || $_REQUEST['secret'] != $secret) {
-    $response->outputErrorMessage('Incorrect processing secret. Check your settings.');
+    Response::outputErrorMessage('Incorrect processing secret. Check your settings.');
     die(0);
   }
-} 
+}
 $enforceSSL = getConfig('restapi_enforcessl');
 if ($enforceSSL && empty($_SERVER['HTTPS'])) {
-    $response->outputErrorMessage('Invalid API request. Request is not using SSL, which is enforced by the plugin settings.');
+    Response::outputErrorMessage('Invalid API request. Request is not using SSL, which is enforced by the plugin settings.');
     die(0);
 }
 

--- a/plugins/restapi_test.php
+++ b/plugins/restapi_test.php
@@ -27,9 +27,9 @@ class restapi_test extends phplistPlugin
     ),
   );
 
-    public function restapi_test()
+    public function __construct()
     {
-        parent::phplistplugin();
+        parent::__construct();
         $this->coderoot = dirname(__FILE__).'/restapi_test/';
     }
 

--- a/plugins/restapi_test/main.php
+++ b/plugins/restapi_test/main.php
@@ -18,12 +18,12 @@ $password = getConfig('restapi_test_password');
 if (empty($login)) {
     print Error('Please configure the login details in the settings page<br/>Parameters: <strong>restapi_test_login</strong> and <strong>restapi_test_password</strong> for admin login.');
     ?>
-		<form method="POST">
-			<input type="text" placeholder="restapi_test_login" name="restapi_test_login" /><br/>
-			<input type="password" placeholder="restapi_test_password" name="restapi_test_password" /><br/>
-			<input type="submit" value="Save" />
-		</form>
-	<?php
+        <form method="POST">
+            <input type="text" placeholder="restapi_test_login" name="restapi_test_login" /><br/>
+            <input type="password" placeholder="restapi_test_password" name="restapi_test_password" /><br/>
+            <input type="submit" value="Save" />
+        </form>
+    <?php
 
   return;
 }
@@ -187,8 +187,8 @@ $step = 1;
 
     ?>
 
-		<h2>Step <?php echo $step++; ?> - Count subscribers / subscribers AGAIN!</h2>
-		<?php
+        <h2>Step <?php echo $step++; ?> - Count subscribers / subscribers AGAIN!</h2>
+        <?php
 
         $result = $api->subscribersGet();
         if ($result->status != 'success') {
@@ -395,7 +395,7 @@ $step = 1;
 
     ?>
 
-		<h2>The test completed successfully!</h2>
+        <h2>The test completed successfully!</h2>
 
 </html>
 
@@ -406,28 +406,27 @@ $step = 1;
      */
     function apiUrl($website)
     {
-        $url = '';
+        global $adminpages, $website;
 
         if (!empty($_SERVER['HTTPS'])) {
 
             // Check which protocol to use
             if ($_SERVER['HTTPS'] !== 'off') {
-                $url = 'https://'; //https
+                $scheme = 'https'; //https
             } else {
-                $url = 'http://'; //http
+                $scheme = 'http'; //http
             }
         } else {
-            $url = 'http://'; //http
+            $scheme = 'http'; //http
         }
+        $params = ['page' => 'call', 'pi' => 'restapi'];
 
-        $api_url = str_replace('page=main&pi=restapi_test', 'page=call&pi=restapi', $_SERVER['REQUEST_URI']);
-        $api_url = preg_replace('/\&tk\=[^&]*/', '', $api_url);
-        $api_url1 = str_replace('page=main&pi=restapi', 'page=call&pi=restapi', $api_url);
+        if (getConfig('restapi_usesecret')) {
+            $params['secret'] = getConfig('remote_processing_secret');
+        }
+        $url = sprintf('%s://%s%s/?%s', $scheme, $website, $adminpages, http_build_query($params));
 
-        $concatenatedUrl = $url.$website.$api_url1;
-        $trimmedUrl = rtrim($concatenatedUrl, '/');
-
-        return $trimmedUrl;
+        return $url;
     }
 
 ?>


### PR DESCRIPTION
Three small changes for problems I found when trying to run the tests provided by the `restapi_test` class.

1) Rename the constructor of the `restapi_test` class to avoid php deprecation warning when running php from the command line

`PHP Deprecated:  Methods with the same name as their class will not be constructors in a future version of PHP; restapi_test has a deprecated constructor in /home/duncan/Development/GitHub/phplist-plugin-restapi/plugins/restapi_test.php on line 7`

2) Fix a problem with the `restapi` class. When running the tests, the `restapi` class doesn't return an error message correctly in some cases.

3) Simplify the derivation of the URL to call when running tests and include the secret parameter if that is required.